### PR TITLE
feature/whilePaused event for scripts

### DIFF
--- a/Core/Debugger.cpp
+++ b/Core/Debugger.cpp
@@ -1003,9 +1003,16 @@ bool Debugger::SleepUntilResume(BreakSource source, uint32_t breakpointId, Break
 
 		_executionStopped = true;
 		_pausedForDebugHelper = breakRequested;
+		int whilePausedRunCounter = 0;
 		while((((stepCount == 0 || _breakRequested) && _suspendCount == 0) || _preventResume > 0) && !_stopFlag) {
 			std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(10));
-			if (preventResume == 0) ProcessEvent(EventType::WhilePaused);
+			if (preventResume == 0) {
+				whilePausedRunCounter++;
+				if (whilePausedRunCounter > 10) {
+					ProcessEvent(EventType::WhilePaused);
+					whilePausedRunCounter = 0;
+				}
+			}
 			if(stepCount == 0) {
 				_console->ResetRunTimers();
 			}

--- a/Core/Debugger.cpp
+++ b/Core/Debugger.cpp
@@ -1005,6 +1005,7 @@ bool Debugger::SleepUntilResume(BreakSource source, uint32_t breakpointId, Break
 		_pausedForDebugHelper = breakRequested;
 		while((((stepCount == 0 || _breakRequested) && _suspendCount == 0) || _preventResume > 0) && !_stopFlag) {
 			std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(10));
+			if (preventResume == 0) ProcessEvent(EventType::WhilePaused);
 			if(stepCount == 0) {
 				_console->ResetRunTimers();
 			}

--- a/Core/DebuggerTypes.h
+++ b/Core/DebuggerTypes.h
@@ -203,6 +203,7 @@ enum class EventType
 	SpriteZeroHit = 9,
 	ScriptEnded = 10,
 	BusConflict = 11,
+	WhilePaused = 12,
 	EventTypeSize
 };
 

--- a/Core/LuaApi.cpp
+++ b/Core/LuaApi.cpp
@@ -168,6 +168,7 @@ int LuaApi::GetLibrary(lua_State *lua)
 	lua_pushintvalue(stateSaved, EventType::StateSaved);
 	lua_pushintvalue(inputPolled, EventType::InputPolled);
 	lua_pushintvalue(scriptEnded, EventType::ScriptEnded);
+	lua_pushintvalue(whilePaused, EventType::WhilePaused);
 	lua_settable(lua, -3);
 
 	lua_pushliteral(lua, "executeCountType");

--- a/GUI.NET/Debugger/frmScript.cs
+++ b/GUI.NET/Debugger/frmScript.cs
@@ -533,6 +533,7 @@ namespace Mesen.GUI.Debugger
 			new List<string> {"func","emu.getState","emu.getState()","","* Table* Current emulation state","Return a table containing information about the state of the CPU, PPU, APU and cartridge."},
 			new List<string> {"func","emu.setState","emu.setState(state)","state - *Table* A table containing the state of the emulation to apply.","","Updates the CPU and PPU's state.\nThe* state* parameter must be a table in the same format as the one returned by getState()\nNote: the state of the APU or cartridge cannot be modified by using setState()." },
 			new List<string> {"func","emu.breakExecution","emu.breakExecution()","","","Breaks the execution of the game and displays the debugger window."},
+			new List<string> {"func","emu.stop","emu.stop()","","","Stops execution of the game."},
 			new List<string> {"func","emu.execute","emu.execute(count, type)","count - *Integer* The number of cycles or instructions to run before breaking\ntype - *Enum* See executeCountType","","Runs the emulator for the specified number of cycles/instructions and then breaks the execution."},
 			new List<string> {"func","emu.reset","emu.reset()","","","Resets the current game."},
 			new List<string> {"func","emu.resume","emu.resume()","","","Resumes execution after breaking."},

--- a/GUI.NET/Debugger/frmScript.cs
+++ b/GUI.NET/Debugger/frmScript.cs
@@ -578,6 +578,7 @@ namespace Mesen.GUI.Debugger
 			new List<string> {"enum","emu.eventType.inputPolled","Triggered when the emulation core polls the state of the input devices for the next frame","","",""},
 			new List<string> {"enum","emu.eventType.spriteZeroHit","Triggered when the PPU sets the sprite zero hit flag","","",""},
 			new List<string> {"enum","emu.eventType.scriptEnded","Triggered when the current Lua script ends (script window closed, execution stopped, etc.)","","",""},
+			new List<string> {"enum","emu.eventType.whilePaused","Triggered repeatedly while execution is paused","","",""},
 			new List<string> {"enum","emu.executeCountType","emu.executeCountType.[value]","","","Values:\ncpuCycles = 0,\nppuCycles = 1,\ncpuInstructions = 2\n\nUsed by execute calls." },
 			new List<string> {"enum","emu.executeCountType.cpuCycles","Count the number of CPU cycles","","",""},
 			new List<string> {"enum","emu.executeCountType.ppuCycles","Count the number of PPU cycles","","",""},


### PR DESCRIPTION
This PR adds `emu.eventType.whilePaused` to the list of available callbacks available to debugger scripts via `emu.addEventCallback(...)`. In contrast with the other available events that run frequently when a rom is running, the `whilePaused` event runs while a rom is paused. This allows a script to be able to both pause (via `emu.breakExecution()`) and resume (via `emu.resume()`) in asynchronous code (e.g. with `LuaSocket`).

This simplified script should allow testing this effect. After a short period it should pause, and after another short period it should resume and repeat this process.
```
local counter = 0
local pauseCount = 0

function testfn()
    counter = counter + 1
    if counter > 500 then
      emu.breakExecution()
      emu.displayMessage("async test", "pause" .. pauseCount)
      counter = 0
      return
    end
end
  
function whilepaused()
    pauseCount = pauseCount + 1
    if pauseCount > 500 then
      emu.resume()
      
      emu.displayMessage("async test", "resume" .. counter)
      pauseCount = 0
      return
    end
end

emu.displayMessage("async test", "init")

emu.addEventCallback(testfn, emu.eventType.endFrame)
emu.addEventCallback(whilepaused, emu.eventType.whilePaused)
```