### PR TITLE
Load .dbg file when launched with scripts

### DIFF
--- a/GUI.NET/Forms/frmMain.cs
+++ b/GUI.NET/Forms/frmMain.cs
@@ -691,7 +691,7 @@ namespace Mesen.GUI.Forms
 
 					this.StartEmuThread();
 					this.BeginInvoke((MethodInvoker)(() => {
-						if(DebugWindowManager.HasOpenedWindow) {
+						if(DebugWindowManager.HasOpenedWindow || _luaScriptsToLoad.Count > 0) {
 							DebugWorkspaceManager.GetWorkspace();
 							DebugWorkspaceManager.AutoLoadDbgFiles(true);
 						}


### PR DESCRIPTION
Currently when mesen is launched with scripts passed as command line args, the `AutoLoadDbgFiles()` function never gets called... because the Debug Window is loaded in an unusual way that keeps it hidden while allowing the Scripts Window to be opened. (Normally, opening the Debug Window for the first time is followed by calling `AutoLoadDbgFiles()`, which doesn't happen in this specific case).

This PR is to fix that, allowing the dbg file to be loaded when launched with scripts. 