### PR TITLE
Build against an older version of Ubuntu to attempt to increase native code backwards compatibility

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,15 +1,21 @@
 name: "Linux build"
-on: push
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   linux-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up dependencies
         run: |
-          sudo apt-get -qq update
-          sudo apt-get install -yq libsdl2-dev mono-devel
+          sudo apt-get install -yq --no-install-recommends gnupg ca-certificates
+          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+          echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          sudo apt-get update
+          sudo apt-get install -yq --no-install-recommends mono-devel libsdl2-dev libsdl2-2.0 gnome-themes-standard xvfb x11-apps
+          sudo apt-get clean && sudo rm -rf /var/cache/apt/lists/*
       - name: Build
         run: |
           make


### PR DESCRIPTION
Seems not to break anything. I tested this against my system running 20.04 (focal) and tried to run "Quantum Disco Brothers" by wAMMA and it seems to work correctly still.

libc version report:
```sh
> objdump -T ~/Downloads/libMesenCore-bionic.dll | grep -i libc | awk -F'\t' '{ print $2 }' | awk -F' ' '{ print $2 }' | sort | uniq
GLIBC_2.14
GLIBC_2.2.5
GLIBC_2.27
GLIBC_2.3
GLIBC_2.3.2
GLIBCXX_3.4
GLIBCXX_3.4.11
GLIBCXX_3.4.14
GLIBCXX_3.4.15
GLIBCXX_3.4.18
GLIBCXX_3.4.19
GLIBCXX_3.4.20
GLIBCXX_3.4.21
GLIBCXX_3.4.22
GLIBCXX_3.4.26
GLIBCXX_3.4.9
empathicqubit@sager-laptop:~/Mesen-X [ git: = ] 
> objdump -T ~/Downloads/libMesenCore.dll | grep -i libc | awk -F'\t' '{ print $2 }' | awk -F' ' '{ print $2 }' | sort | uniq
GLIBC_2.14
GLIBC_2.2.5
GLIBC_2.27
GLIBC_2.29
GLIBC_2.3
GLIBC_2.3.2
GLIBCXX_3.4
GLIBCXX_3.4.11
GLIBCXX_3.4.14
GLIBCXX_3.4.15
GLIBCXX_3.4.18
GLIBCXX_3.4.19
GLIBCXX_3.4.20
GLIBCXX_3.4.21
GLIBCXX_3.4.22
GLIBCXX_3.4.26
GLIBCXX_3.4.9
empathicqubit@sager-laptop:~/Mesen-X [ git: = ] 
> objdump -T ~/Downloads/libMesenCore.dll | grep -i libc | awk -F'\t' '{ print $2 }' | awk -F' ' '{ print $2 $3 }' | sort | uniq | grep 2.29
GLIBC_2.29exp
GLIBC_2.29log
GLIBC_2.29log2
GLIBC_2.29pow
empathicqubit@sager-laptop:~/Mesen-X [ git: = ] 
> objdump -T ~/Downloads/libMesenCore-bionic.dll | grep -i libc | awk -F'\t' '{ print $2 }' | awk -F' ' '{ print $2 $3 }' | sort | uniq | grep 'exp\|log\|pow'
GLIBC_2.2.5exp
GLIBC_2.2.5frexp
GLIBC_2.2.5ldexp
GLIBC_2.2.5ldexpf
GLIBC_2.2.5log
GLIBC_2.2.5log10
GLIBC_2.2.5log2
GLIBC_2.2.5pow
GLIBC_2.27expf
GLIBC_2.27logf
GLIBC_2.27powf
GLIBCXX_3.4_ZSt19__throw_logic_errorPKc
empathicqubit@sager-laptop:~/Mesen-X [ git: = ] 
> 
```
https://www.phoronix.com/scan.php?page=news_item&px=Glibc-2.29-Released