### PR TITLE
Add alternative YIQ to RGB conversion equation (SMPTE C)

### DIFF
--- a/Core/BisqwitNtscFilter.h
+++ b/Core/BisqwitNtscFilter.h
@@ -20,6 +20,7 @@ private:
 	atomic<bool> _workDone;
 
 	bool _keepVerticalRes = false;
+	bool _SMPTE_C = false;
 
 	int _resDivider = 1;
 	uint16_t *_ppuOutputBuffer = nullptr;
@@ -33,8 +34,8 @@ private:
 	*/
 	int _yWidth, _iWidth, _qWidth;
 	int _y;
-	int _ir, _ig, _ib;
-	int _qr, _qg, _qb;
+	int _ir, _ig, _ib, _irC, _igC, _ibC;
+	int _qr, _qg, _qb, _qrC, _qgC, _qbC;
 
 	//To finetune hue, you would have to recalculate sinetable[]. (Coarse changes can be made with Phase0.)
 	int8_t _sinetable[27]; // 8*sin(x*2pi/12)

--- a/Core/BisqwitNtscFilter.h
+++ b/Core/BisqwitNtscFilter.h
@@ -44,14 +44,14 @@ private:
 
 	void RecursiveBlend(int iterationCount, uint64_t *output, uint64_t *currentLine, uint64_t *nextLine, int pixelsPerCycle, bool verticalBlend);
 	
-	void NtscDecodeLine(int width, const int8_t* signal, uint32_t* target, int phase0);
+	void NtscDecodeLine(int width, const int8_t* signal, uint32_t* target, int phase0, bool SMPTE_C);
 	
 	void GenerateNtscSignal(int8_t *ntscSignal, int &phase, int rowNumber);
-	void DecodeFrame(int startRow, int endRow, uint16_t *ppuOutputBuffer, uint32_t* outputBuffer, int startPhase);
+	void DecodeFrame(int startRow, int endRow, uint16_t *ppuOutputBuffer, uint32_t* outputBuffer, int startPhase, bool SMPTE_C);
 	void OnBeforeApplyFilter();
 
 public:
-	BisqwitNtscFilter(shared_ptr<Console> console, int resDivider);
+	BisqwitNtscFilter(shared_ptr<Console> console, int resDivider, bool SMPTE_C);
 	virtual ~BisqwitNtscFilter();
 
 	virtual void ApplyFilter(uint16_t *ppuOutputBuffer);

--- a/Core/EmulationSettings.h
+++ b/Core/EmulationSettings.h
@@ -171,6 +171,9 @@ enum class VideoFilterType
 	Prescale8x = 23,
 	Prescale10x = 24,
 	Raw = 25,
+	BisqwitNtscSMPTECQuarterRes = 26,
+	BisqwitNtscSMPTECHalfRes = 27,
+	BisqwitNtscSMPTEC = 28,
 	HdPack = 999
 };
 

--- a/Core/ScaleFilter.cpp
+++ b/Core/ScaleFilter.cpp
@@ -107,6 +107,9 @@ shared_ptr<ScaleFilter> ScaleFilter::GetScaleFilter(VideoFilterType filter)
 		case VideoFilterType::BisqwitNtsc:
 		case VideoFilterType::BisqwitNtscHalfRes:
 		case VideoFilterType::BisqwitNtscQuarterRes:
+		case VideoFilterType::BisqwitNtscSMPTEC:
+		case VideoFilterType::BisqwitNtscSMPTECHalfRes:
+		case VideoFilterType::BisqwitNtscSMPTECQuarterRes:
 		case VideoFilterType::NTSC:
 		case VideoFilterType::HdPack:
 		case VideoFilterType::Raw:

--- a/Core/VideoDecoder.cpp
+++ b/Core/VideoDecoder.cpp
@@ -70,9 +70,12 @@ void VideoDecoder::UpdateVideoFilter()
 		switch(_videoFilterType) {
 			case VideoFilterType::None: break;
 			case VideoFilterType::NTSC: _videoFilter.reset(new NtscFilter(_console)); break;
-			case VideoFilterType::BisqwitNtsc: _videoFilter.reset(new BisqwitNtscFilter(_console, 1)); break;
-			case VideoFilterType::BisqwitNtscHalfRes: _videoFilter.reset(new BisqwitNtscFilter(_console, 2)); break;
-			case VideoFilterType::BisqwitNtscQuarterRes: _videoFilter.reset(new BisqwitNtscFilter(_console, 4)); break;
+			case VideoFilterType::BisqwitNtsc: _videoFilter.reset(new BisqwitNtscFilter(_console, 1, false)); break;
+			case VideoFilterType::BisqwitNtscHalfRes: _videoFilter.reset(new BisqwitNtscFilter(_console, 2, false)); break;
+			case VideoFilterType::BisqwitNtscQuarterRes: _videoFilter.reset(new BisqwitNtscFilter(_console, 4, false)); break;
+			case VideoFilterType::BisqwitNtscSMPTEC: _videoFilter.reset(new BisqwitNtscFilter(_console, 1, true)); break;
+			case VideoFilterType::BisqwitNtscSMPTECHalfRes: _videoFilter.reset(new BisqwitNtscFilter(_console, 2, true)); break;
+			case VideoFilterType::BisqwitNtscSMPTECQuarterRes: _videoFilter.reset(new BisqwitNtscFilter(_console, 4, true)); break;
 			case VideoFilterType::Raw: _videoFilter.reset(new RawVideoFilter(_console)); break;
 			default: _scaleFilter = ScaleFilter::GetScaleFilter(_videoFilterType); break;
 		}

--- a/GUI.NET/Forms/Config/frmVideoConfig.cs
+++ b/GUI.NET/Forms/Config/frmVideoConfig.cs
@@ -165,7 +165,12 @@ namespace Mesen.GUI.Forms.Config
 				tlpNtscFilter2.Visible = false;
 				chkMergeFields.Visible = true;
 				grpNtscFilter.Visible = true;
-			} else if(filter == VideoFilterType.BisqwitNtsc || filter == VideoFilterType.BisqwitNtscHalfRes || filter == VideoFilterType.BisqwitNtscQuarterRes) {
+			} else if(filter == VideoFilterType.BisqwitNtsc ||
+				filter == VideoFilterType.BisqwitNtscHalfRes ||
+				filter == VideoFilterType.BisqwitNtscQuarterRes ||
+				filter == VideoFilterType.BisqwitNtscSMPTEC ||
+				filter == VideoFilterType.BisqwitNtscSMPTECHalfRes ||
+				filter == VideoFilterType.BisqwitNtscSMPTECQuarterRes) {
 				tlpNtscFilter1.Visible = true;
 				tlpNtscFilter2.Visible = true;
 				chkMergeFields.Visible = false;

--- a/GUI.NET/Forms/frmMain.Designer.cs
+++ b/GUI.NET/Forms/frmMain.Designer.cs
@@ -106,6 +106,9 @@ namespace Mesen.GUI.Forms
 			this.mnuNtscBisqwitQuarterFilter = new System.Windows.Forms.ToolStripMenuItem();
 			this.mnuNtscBisqwitHalfFilter = new System.Windows.Forms.ToolStripMenuItem();
 			this.mnuNtscBisqwitFullFilter = new System.Windows.Forms.ToolStripMenuItem();
+			this.mnuNtscSMPTECBisqwitQuarterFilter = new System.Windows.Forms.ToolStripMenuItem();
+			this.mnuNtscSMPTECBisqwitHalfFilter = new System.Windows.Forms.ToolStripMenuItem();
+			this.mnuNtscSMPTECBisqwitFullFilter = new System.Windows.Forms.ToolStripMenuItem();
 			this.toolStripMenuItem15 = new System.Windows.Forms.ToolStripSeparator();
 			this.mnuXBRZ2xFilter = new System.Windows.Forms.ToolStripMenuItem();
 			this.mnuXBRZ3xFilter = new System.Windows.Forms.ToolStripMenuItem();
@@ -831,6 +834,9 @@ namespace Mesen.GUI.Forms
             this.mnuNtscBisqwitQuarterFilter,
             this.mnuNtscBisqwitHalfFilter,
             this.mnuNtscBisqwitFullFilter,
+            this.mnuNtscSMPTECBisqwitQuarterFilter,
+            this.mnuNtscSMPTECBisqwitHalfFilter,
+            this.mnuNtscSMPTECBisqwitFullFilter,
             this.toolStripMenuItem15,
             this.mnuXBRZ2xFilter,
             this.mnuXBRZ3xFilter,
@@ -902,6 +908,27 @@ namespace Mesen.GUI.Forms
 			this.mnuNtscBisqwitFullFilter.Size = new System.Drawing.Size(206, 22);
 			this.mnuNtscBisqwitFullFilter.Text = "NTSC 8x (Bisqwit)";
 			this.mnuNtscBisqwitFullFilter.Click += new System.EventHandler(this.mnuNtscBisqwitFullFilter_Click);
+			// 
+			// mnuNtscSMPTECBisqwitQuarterFilter
+			// 
+			this.mnuNtscSMPTECBisqwitQuarterFilter.Name = "mnuNtscSMPTECBisqwitQuarterFilter";
+			this.mnuNtscSMPTECBisqwitQuarterFilter.Size = new System.Drawing.Size(206, 22);
+			this.mnuNtscSMPTECBisqwitQuarterFilter.Text = "NTSC SMPTE C 2x (Bisqwit)";
+			this.mnuNtscSMPTECBisqwitQuarterFilter.Click += new System.EventHandler(this.mnuNtscSMPTECBisqwitQuarterFilter_Click);
+			// 
+			// mnuNtscSMPTECBisqwitHalfFilter
+			// 
+			this.mnuNtscSMPTECBisqwitHalfFilter.Name = "mnuNtscSMPTECBisqwitHalfFilter";
+			this.mnuNtscSMPTECBisqwitHalfFilter.Size = new System.Drawing.Size(206, 22);
+			this.mnuNtscSMPTECBisqwitHalfFilter.Text = "NTSC SMPTE C 4x (Bisqwit)";
+			this.mnuNtscSMPTECBisqwitHalfFilter.Click += new System.EventHandler(this.mnuNtscSMPTECBisqwitHalfFilter_Click);
+			// 
+			// mnuNtscSMPTECBisqwitFullFilter
+			// 
+			this.mnuNtscSMPTECBisqwitFullFilter.Name = "mnuNtscSMPTECBisqwitFullFilter";
+			this.mnuNtscSMPTECBisqwitFullFilter.Size = new System.Drawing.Size(206, 22);
+			this.mnuNtscSMPTECBisqwitFullFilter.Text = "NTSC SMPTE C 8x (Bisqwit)";
+			this.mnuNtscSMPTECBisqwitFullFilter.Click += new System.EventHandler(this.mnuNtscSMPTECBisqwitFullFilter_Click);
 			// 
 			// toolStripMenuItem15
 			// 
@@ -1977,6 +2004,9 @@ namespace Mesen.GUI.Forms
 		private System.Windows.Forms.ToolStripMenuItem mnuNtscBisqwitHalfFilter;
 		private System.Windows.Forms.ToolStripMenuItem mnuNtscBisqwitFullFilter;
 		private System.Windows.Forms.ToolStripMenuItem mnuNtscBisqwitQuarterFilter;
+		private System.Windows.Forms.ToolStripMenuItem mnuNtscSMPTECBisqwitHalfFilter;
+		private System.Windows.Forms.ToolStripMenuItem mnuNtscSMPTECBisqwitFullFilter;
+		private System.Windows.Forms.ToolStripMenuItem mnuNtscSMPTECBisqwitQuarterFilter;
 		private System.Windows.Forms.ToolStripSeparator toolStripMenuItem22;
 		private System.Windows.Forms.ToolStripMenuItem mnuVideoRecorder;
 		private System.Windows.Forms.ToolStripMenuItem mnuAviRecord;

--- a/GUI.NET/Forms/frmMain.Options.cs
+++ b/GUI.NET/Forms/frmMain.Options.cs
@@ -52,6 +52,9 @@ namespace Mesen.GUI.Forms
 			mnuNtscBisqwitFullFilter.Checked = (filterType == VideoFilterType.BisqwitNtsc);
 			mnuNtscBisqwitHalfFilter.Checked = (filterType == VideoFilterType.BisqwitNtscHalfRes);
 			mnuNtscBisqwitQuarterFilter.Checked = (filterType == VideoFilterType.BisqwitNtscQuarterRes);
+			mnuNtscSMPTECBisqwitFullFilter.Checked = (filterType == VideoFilterType.BisqwitNtscSMPTEC);
+			mnuNtscSMPTECBisqwitHalfFilter.Checked = (filterType == VideoFilterType.BisqwitNtscSMPTECHalfRes);
+			mnuNtscSMPTECBisqwitQuarterFilter.Checked = (filterType == VideoFilterType.BisqwitNtscSMPTECQuarterRes);
 
 			mnuXBRZ2xFilter.Checked = (filterType == VideoFilterType.xBRZ2x);
 			mnuXBRZ3xFilter.Checked = (filterType == VideoFilterType.xBRZ3x);
@@ -369,6 +372,21 @@ namespace Mesen.GUI.Forms
 		private void mnuNtscBisqwitQuarterFilter_Click(object sender, EventArgs e)
 		{
 			SetVideoFilter(VideoFilterType.BisqwitNtscQuarterRes);
+		}
+
+		private void mnuNtscSMPTECBisqwitFullFilter_Click(object sender, EventArgs e)
+		{
+			SetVideoFilter(VideoFilterType.BisqwitNtscSMPTEC);
+		}
+
+		private void mnuNtscSMPTECBisqwitHalfFilter_Click(object sender, EventArgs e)
+		{
+			SetVideoFilter(VideoFilterType.BisqwitNtscSMPTECHalfRes);
+		}
+
+		private void mnuNtscSMPTECBisqwitQuarterFilter_Click(object sender, EventArgs e)
+		{
+			SetVideoFilter(VideoFilterType.BisqwitNtscSMPTECQuarterRes);
 		}
 	}
 }

--- a/GUI.NET/Forms/frmMain.cs
+++ b/GUI.NET/Forms/frmMain.cs
@@ -1363,6 +1363,9 @@ namespace Mesen.GUI.Forms
 					mnuNtscBisqwitQuarterFilter.Enabled = !isHdPackLoader;
 					mnuNtscBisqwitHalfFilter.Enabled = !isHdPackLoader;
 					mnuNtscBisqwitFullFilter.Enabled = !isHdPackLoader;
+					mnuNtscSMPTECBisqwitQuarterFilter.Enabled = !isHdPackLoader;
+					mnuNtscSMPTECBisqwitHalfFilter.Enabled = !isHdPackLoader;
+					mnuNtscSMPTECBisqwitFullFilter.Enabled = !isHdPackLoader;
 				}
 			} catch { }
 		}

--- a/GUI.NET/InteropEmu.cs
+++ b/GUI.NET/InteropEmu.cs
@@ -2362,6 +2362,9 @@ namespace Mesen.GUI
 		Prescale6x = 22,
 		Prescale8x = 23,
 		Prescale10x = 24,
+		BisqwitNtscSMPTECQuarterRes = 26,
+		BisqwitNtscSMPTECHalfRes = 27,
+		BisqwitNtscSMPTEC = 28,
 	}
 
 	public enum HDPackOuputTileType


### PR DESCRIPTION
The old conversion equation values seem to be modified to produce colors closer to the older FCC 1953 NTSC colorimetry. Though accurate for Japanese TV sets, as they still used this standard despite updated color primaries in the SMPTE C specification, this does not reflect other TV sets with mentioned SMPTE C color primaries.