### PR TITLE
Adding delayed writes to $4016 EPSM Addressing

### DIFF
--- a/Core/BaseMapper.cpp
+++ b/Core/BaseMapper.cpp
@@ -789,7 +789,7 @@ uint8_t BaseMapper::DebugReadRAM(uint16_t addr)
 
 void BaseMapper::WriteRAM(uint16_t addr, uint8_t value)
 {
-	if((addr == 0x4016) & (_console->GetCpu()->GetCycleCount() % 2 == 1)){ WriteEPSM(addr, value); }
+	if(addr == 0x4016){ WriteEPSM(addr, value); }
 	if ((addr >= 0x401c && addr <= 0x401f)) {WriteEPSM(addr, value); }
 	if(_isWriteRegisterAddr[addr]) {
 		if(_hasBusConflicts) {

--- a/Core/EPSMAudio.h
+++ b/Core/EPSMAudio.h
@@ -264,12 +264,12 @@ public:
 		if (!custom) {
 			switch (addr) {
 			case 0x4016:
-				if ((value & 0x0F) == 0x02) {writeAddr = 0x0;} //A0 = 0, A1 = 0
-				if ((value & 0x0F) == 0x0A) {writeAddr = 0x1;} //A0 = 1, A1 = 0
-				if ((value & 0x0F) == 0x06) {writeAddr = 0x2;} //A0 = 0, A1 = 1
-				if ((value & 0x0F) == 0x0E) {writeAddr = 0x3;} //A0 = 1, A1 = 1
+				if ((value & 0x0E) == 0x02) {writeAddr = 0x0;} //A0 = 0, A1 = 0
+				if ((value & 0x0E) == 0x0A) {writeAddr = 0x1;} //A0 = 1, A1 = 0
+				if ((value & 0x0E) == 0x06) {writeAddr = 0x2;} //A0 = 0, A1 = 1
+				if ((value & 0x0E) == 0x0E) {writeAddr = 0x3;} //A0 = 1, A1 = 1
 				if (value & 0x0E) {writeValue = value;}
-				if ((value & 0x0F) == 0x00) {
+				if ((value & 0x02) == 0x00) {
 					writeValue = (writeValue & 0xF0) | (value >> 4);
 
 					const uint8_t a0 = !!(writeAddr & 0x1);

--- a/Core/MemoryManager.h
+++ b/Core/MemoryManager.h
@@ -24,6 +24,8 @@ class MemoryManager : public Snapshotable
 		InternalRamHandler<0x7FF> _internalRamHandler;
 		IMemoryHandler** _ramReadHandlers;
 		IMemoryHandler** _ramWriteHandlers;
+		bool _out1_latch;
+		uint8_t _out_delay;
 
 		void InitializeMemoryHandlers(IMemoryHandler** memoryHandlers, IMemoryHandler* handler, vector<uint16_t> *addresses, bool allowOverride);
 


### PR DESCRIPTION
Adjusted the actual data the EPSM gets because of the delayed latching of OUT1 on even CPU cycles.