### PR TITLE
Composite Filter Improvements

### DIFF
--- a/Core/BaseVideoFilter.cpp
+++ b/Core/BaseVideoFilter.cpp
@@ -52,11 +52,17 @@ bool BaseVideoFilter::IsOddFrame()
 	return _isOddFrame;
 }
 
+uint8_t BaseVideoFilter::GetFieldPhase()
+{
+	return _fieldPhase;
+}
+
 void BaseVideoFilter::SendFrame(uint16_t *ppuOutputBuffer, uint32_t frameNumber)
 {
 	_frameLock.Acquire();
 	_overscan = _console->GetSettings()->GetOverscanDimensions();
-	_isOddFrame = frameNumber % 2;
+	_isOddFrame = frameNumber & 0x01;
+	_fieldPhase = frameNumber % 3;
 	UpdateBufferSize();
 	OnBeforeApplyFilter();
 	ApplyFilter(ppuOutputBuffer);

--- a/Core/BaseVideoFilter.cpp
+++ b/Core/BaseVideoFilter.cpp
@@ -52,17 +52,11 @@ bool BaseVideoFilter::IsOddFrame()
 	return _isOddFrame;
 }
 
-uint8_t BaseVideoFilter::GetFieldPhase()
-{
-	return _fieldPhase;
-}
-
 void BaseVideoFilter::SendFrame(uint16_t *ppuOutputBuffer, uint32_t frameNumber)
 {
 	_frameLock.Acquire();
 	_overscan = _console->GetSettings()->GetOverscanDimensions();
 	_isOddFrame = frameNumber & 0x01;
-	_fieldPhase = frameNumber % 3;
 	UpdateBufferSize();
 	OnBeforeApplyFilter();
 	ApplyFilter(ppuOutputBuffer);

--- a/Core/BaseVideoFilter.h
+++ b/Core/BaseVideoFilter.h
@@ -15,8 +15,6 @@ private:
 	SimpleLock _frameLock;
 	OverscanDimensions _overscan;
 	bool _isOddFrame;
-	// https://forums.nesdev.org/viewtopic.php?p=30625#p30625
-	uint8_t _fieldPhase;
 
 	void UpdateBufferSize();
 
@@ -25,7 +23,6 @@ protected:
 
 	virtual void ApplyFilter(uint16_t *ppuOutputBuffer) = 0;
 	virtual void OnBeforeApplyFilter();
-	uint8_t GetFieldPhase();
 
 public:
 	BaseVideoFilter(shared_ptr<Console> console);

--- a/Core/BaseVideoFilter.h
+++ b/Core/BaseVideoFilter.h
@@ -15,6 +15,8 @@ private:
 	SimpleLock _frameLock;
 	OverscanDimensions _overscan;
 	bool _isOddFrame;
+	// https://forums.nesdev.org/viewtopic.php?p=30625#p30625
+	uint8_t _fieldPhase;
 
 	void UpdateBufferSize();
 
@@ -23,13 +25,14 @@ protected:
 
 	virtual void ApplyFilter(uint16_t *ppuOutputBuffer) = 0;
 	virtual void OnBeforeApplyFilter();
-	bool IsOddFrame();
+	uint8_t GetFieldPhase();
 
 public:
 	BaseVideoFilter(shared_ptr<Console> console);
 	virtual ~BaseVideoFilter();
 
 	uint32_t* GetOutputBuffer();
+	bool IsOddFrame();
 	void SendFrame(uint16_t *ppuOutputBuffer, uint32_t frameNumber);
 	void TakeScreenshot(string romName, VideoFilterType filterType);
 	void TakeScreenshot(VideoFilterType filterType, string filename, std::stringstream *stream = nullptr, bool rawScreenshot = false);

--- a/Core/BisqwitNtscFilter.cpp
+++ b/Core/BisqwitNtscFilter.cpp
@@ -50,8 +50,7 @@ BisqwitNtscFilter::BisqwitNtscFilter(shared_ptr<Console> console, int resDivider
 			} else {
 				outputBuffer += GetOverscan().GetScreenWidth() * 64 / _resDivider / _resDivider * (120 - GetOverscan().Top);
 			}
-
-			DecodeFrame(120, 239 - GetOverscan().Bottom, _ppuOutputBuffer, outputBuffer, (IsOddFrame() ? 8 : 0) + 327360); 
+			DecodeFrame(120, 239 - GetOverscan().Bottom, _ppuOutputBuffer, outputBuffer, (_console->IsDotBypassed() ? (GetFieldPhase() * 4) : (IsOddFrame() ? 0 : 8)) + 327360);
 
 			_workDone = true;
 		}
@@ -71,7 +70,7 @@ void BisqwitNtscFilter::ApplyFilter(uint16_t *ppuOutputBuffer)
 
 	_workDone = false;
 	_waitWork.Signal();
-	DecodeFrame(GetOverscan().Top, 120, ppuOutputBuffer, GetOutputBuffer(), (IsOddFrame() ? 8 : 0) + GetOverscan().Top*341*8);
+	DecodeFrame(GetOverscan().Top, 120, ppuOutputBuffer, GetOutputBuffer(), (_console->IsDotBypassed() ? (GetFieldPhase() * 4) : (IsOddFrame() ? 0 : 8)) + GetOverscan().Top * 341 * 8);
 	while(!_workDone) {}
 }
 

--- a/Core/BisqwitNtscFilter.cpp
+++ b/Core/BisqwitNtscFilter.cpp
@@ -50,7 +50,7 @@ BisqwitNtscFilter::BisqwitNtscFilter(shared_ptr<Console> console, int resDivider
 			} else {
 				outputBuffer += GetOverscan().GetScreenWidth() * 64 / _resDivider / _resDivider * (120 - GetOverscan().Top);
 			}
-			DecodeFrame(120, 239 - GetOverscan().Bottom, _ppuOutputBuffer, outputBuffer, (_console->GetStartingPhase() * 4) + 327360);
+			DecodeFrame(120, 239 - GetOverscan().Bottom, _ppuOutputBuffer, outputBuffer, ((_console->GetModel() == NesModel::NTSC ? _console->GetStartingPhase() : 0) * 4) + 327360);
 
 			_workDone = true;
 		}
@@ -70,7 +70,7 @@ void BisqwitNtscFilter::ApplyFilter(uint16_t *ppuOutputBuffer)
 
 	_workDone = false;
 	_waitWork.Signal();
-	DecodeFrame(GetOverscan().Top, 120, ppuOutputBuffer, GetOutputBuffer(), (_console->GetStartingPhase() * 4) + GetOverscan().Top * 341 * 8);
+	DecodeFrame(GetOverscan().Top, 120, ppuOutputBuffer, GetOutputBuffer(), ((_console->GetModel() == NesModel::NTSC ? _console->GetStartingPhase() : 0) * 4) + GetOverscan().Top * 341 * 8);
 	while(!_workDone) {}
 }
 

--- a/Core/BisqwitNtscFilter.cpp
+++ b/Core/BisqwitNtscFilter.cpp
@@ -50,7 +50,7 @@ BisqwitNtscFilter::BisqwitNtscFilter(shared_ptr<Console> console, int resDivider
 			} else {
 				outputBuffer += GetOverscan().GetScreenWidth() * 64 / _resDivider / _resDivider * (120 - GetOverscan().Top);
 			}
-			DecodeFrame(120, 239 - GetOverscan().Bottom, _ppuOutputBuffer, outputBuffer, (_console->IsDotBypassed() ? (GetFieldPhase() * 4) : (IsOddFrame() ? 0 : 8)) + 327360);
+			DecodeFrame(120, 239 - GetOverscan().Bottom, _ppuOutputBuffer, outputBuffer, (_console->GetStartingPhase() * 4) + 327360);
 
 			_workDone = true;
 		}
@@ -70,7 +70,7 @@ void BisqwitNtscFilter::ApplyFilter(uint16_t *ppuOutputBuffer)
 
 	_workDone = false;
 	_waitWork.Signal();
-	DecodeFrame(GetOverscan().Top, 120, ppuOutputBuffer, GetOutputBuffer(), (_console->IsDotBypassed() ? (GetFieldPhase() * 4) : (IsOddFrame() ? 0 : 8)) + GetOverscan().Top * 341 * 8);
+	DecodeFrame(GetOverscan().Top, 120, ppuOutputBuffer, GetOutputBuffer(), (_console->GetStartingPhase() * 4) + GetOverscan().Top * 341 * 8);
 	while(!_workDone) {}
 }
 

--- a/Core/Console.cpp
+++ b/Core/Console.cpp
@@ -568,9 +568,9 @@ uint32_t Console::GetFrameCount()
 	return _ppu ? _ppu->GetFrameCount() : 0;
 }
 
-bool Console::IsDotBypassed()
+uint8_t Console::GetStartingPhase()
 {
-	return _ppu ? _ppu->IsDotBypassed() : false;
+	return _ppu ? _ppu->GetStartingPhase() : 0;
 }
 
 NesModel Console::GetModel()

--- a/Core/Console.cpp
+++ b/Core/Console.cpp
@@ -568,6 +568,11 @@ uint32_t Console::GetFrameCount()
 	return _ppu ? _ppu->GetFrameCount() : 0;
 }
 
+bool Console::IsDotBypassed()
+{
+	return _ppu ? _ppu->IsDotBypassed() : false;
+}
+
 NesModel Console::GetModel()
 {
 	return _model;

--- a/Core/Console.h
+++ b/Core/Console.h
@@ -204,6 +204,8 @@ public:
 	VirtualFile GetPatchFile();
 	RomInfo GetRomInfo();
 	uint32_t GetFrameCount();
+	// https://forums.nesdev.org/viewtopic.php?p=30625#p30625
+	bool IsDotBypassed();
 	NesModel GetModel();
 
 	uint32_t GetLagCounter();

--- a/Core/Console.h
+++ b/Core/Console.h
@@ -205,7 +205,7 @@ public:
 	RomInfo GetRomInfo();
 	uint32_t GetFrameCount();
 	// https://forums.nesdev.org/viewtopic.php?p=30625#p30625
-	bool IsDotBypassed();
+	uint8_t GetStartingPhase();
 	NesModel GetModel();
 
 	uint32_t GetLagCounter();

--- a/Core/NtscFilter.cpp
+++ b/Core/NtscFilter.cpp
@@ -132,7 +132,7 @@ void NtscFilter::OnBeforeApplyFilter()
 
 void NtscFilter::ApplyFilter(uint16_t *ppuOutputBuffer)
 {
-	nes_ntsc_blit(&_ntscData, ppuOutputBuffer, _ntsc_border, PPU::ScreenWidth, (_console->IsDotBypassed() ? GetFieldPhase() : IsOddFrame()), PPU::ScreenWidth, 240, _ntscBuffer, NES_NTSC_OUT_WIDTH(PPU::ScreenWidth)*4);
+	nes_ntsc_blit(&_ntscData, ppuOutputBuffer, _ntsc_border, PPU::ScreenWidth, (_console->IsDotBypassed() ? GetFieldPhase() : (IsOddFrame() ? 0 : 2)), PPU::ScreenWidth, 240, _ntscBuffer, NES_NTSC_OUT_WIDTH(PPU::ScreenWidth)*4);
 	GenerateArgbFrame(_ntscBuffer);
 }
 

--- a/Core/NtscFilter.cpp
+++ b/Core/NtscFilter.cpp
@@ -129,7 +129,7 @@ void NtscFilter::ApplyFilter(uint16_t *ppuOutputBuffer)
 		ppuOutputBuffer,
 		_ntscBorder ? _console->GetPpu()->GetCurrentBgColor() : 0x0F,
 		PPU::ScreenWidth,
-		_console->GetStartingPhase(),
+		_console->GetModel() == NesModel::NTSC ? _console->GetStartingPhase() : 0,
 		PPU::ScreenWidth,
 		240, _ntscBuffer,
 		NES_NTSC_OUT_WIDTH(PPU::ScreenWidth)*4);

--- a/Core/NtscFilter.cpp
+++ b/Core/NtscFilter.cpp
@@ -132,7 +132,7 @@ void NtscFilter::OnBeforeApplyFilter()
 
 void NtscFilter::ApplyFilter(uint16_t *ppuOutputBuffer)
 {
-	nes_ntsc_blit(&_ntscData, ppuOutputBuffer, _ntsc_border, PPU::ScreenWidth, (_console->IsDotBypassed() ? GetFieldPhase() : (IsOddFrame() ? 0 : 2)), PPU::ScreenWidth, 240, _ntscBuffer, NES_NTSC_OUT_WIDTH(PPU::ScreenWidth)*4);
+	nes_ntsc_blit(&_ntscData, ppuOutputBuffer, _ntsc_border, PPU::ScreenWidth, _console->GetStartingPhase(), PPU::ScreenWidth, 240, _ntscBuffer, NES_NTSC_OUT_WIDTH(PPU::ScreenWidth)*4);
 	GenerateArgbFrame(_ntscBuffer);
 }
 

--- a/Core/NtscFilter.cpp
+++ b/Core/NtscFilter.cpp
@@ -132,7 +132,7 @@ void NtscFilter::OnBeforeApplyFilter()
 
 void NtscFilter::ApplyFilter(uint16_t *ppuOutputBuffer)
 {
-	nes_ntsc_blit(&_ntscData, ppuOutputBuffer, _ntsc_border, PPU::ScreenWidth, IsOddFrame() ? 0 : 1, PPU::ScreenWidth, 240, _ntscBuffer, NES_NTSC_OUT_WIDTH(PPU::ScreenWidth)*4);
+	nes_ntsc_blit(&_ntscData, ppuOutputBuffer, _ntsc_border, PPU::ScreenWidth, (_console->IsDotBypassed() ? GetFieldPhase() : IsOddFrame()), PPU::ScreenWidth, 240, _ntscBuffer, NES_NTSC_OUT_WIDTH(PPU::ScreenWidth)*4);
 	GenerateArgbFrame(_ntscBuffer);
 }
 

--- a/Core/NtscFilter.cpp
+++ b/Core/NtscFilter.cpp
@@ -55,14 +55,7 @@ void NtscFilter::OnBeforeApplyFilter()
 		}
 	}
 
-	if (_console->GetModel() == NesModel::NTSC) {
-		// BG color borders on NTSC machines
-		_ntsc_border = _console->GetPpu()->GetCurrentBgColor();
-	}
-	else {
-		// black borders on other machines
-		_ntsc_border = 15;
-	}
+	_ntscBorder = (_console->GetModel() == NesModel::NTSC);
 
 	PictureSettings pictureSettings = _console->GetSettings()->GetPictureSettings();
 	NtscFilterSettings ntscSettings = _console->GetSettings()->GetNtscFilterSettings();
@@ -132,7 +125,14 @@ void NtscFilter::OnBeforeApplyFilter()
 
 void NtscFilter::ApplyFilter(uint16_t *ppuOutputBuffer)
 {
-	nes_ntsc_blit(&_ntscData, ppuOutputBuffer, _ntsc_border, PPU::ScreenWidth, _console->GetStartingPhase(), PPU::ScreenWidth, 240, _ntscBuffer, NES_NTSC_OUT_WIDTH(PPU::ScreenWidth)*4);
+	nes_ntsc_blit(&_ntscData,
+		ppuOutputBuffer,
+		_ntscBorder ? _console->GetPpu()->GetCurrentBgColor() : 0x0F,
+		PPU::ScreenWidth,
+		_console->GetStartingPhase(),
+		PPU::ScreenWidth,
+		240, _ntscBuffer,
+		NES_NTSC_OUT_WIDTH(PPU::ScreenWidth)*4);
 	GenerateArgbFrame(_ntscBuffer);
 }
 

--- a/Core/NtscFilter.h
+++ b/Core/NtscFilter.h
@@ -14,7 +14,7 @@ private:
 	bool _useExternalPalette = true;
 	uint8_t _palette[512 * 3];
 	uint32_t* _ntscBuffer;
-	uint16_t _ntsc_border;
+	bool _ntscBorder = true;
 
 	void GenerateArgbFrame(uint32_t *outputBuffer);
 

--- a/Core/PPU.cpp
+++ b/Core/PPU.cpp
@@ -121,22 +121,28 @@ void PPU::SetNesModel(NesModel model)
 			break;
 
 		case NesModel::NTSC:
-			_nmiScanline = 240 + 1;		// picture height + postrender blanking lines
-			_vblankEnd = 240 + 20;		// picture height + (postrender blanking lines - 1) + vblank length
+			// picture height + postrender blanking lines
+			_nmiScanline = 240 + 1;
+			// picture height + (postrender blanking lines - 1) + vblank length
+			_vblankEnd = 240 + 20;
 			_standardNmiScanline = _nmiScanline;
 			_standardVblankEnd = _vblankEnd;
 			_masterClockDivider = 4;
 			break;
 		case NesModel::PAL:
-			_nmiScanline = 239 + 1;		// picture height + postrender blanking lines
-			_vblankEnd = 239 + 70;		// picture height + (postrender blanking lines - 1) + vblank length
+			// (picture height + border line) + postrender blanking lines
+			_nmiScanline = 240 + 1;
+			// (picture height + border line) + (postrender blanking lines - 1) + vblank length + 50
+			_vblankEnd = 240 + 20 + 50;
 			_standardNmiScanline = _nmiScanline;
 			_standardVblankEnd = _vblankEnd;
 			_masterClockDivider = 5;
 			break;
 		case NesModel::Dendy:
-			_nmiScanline = 239 + 51;		// picture height + postrender blanking lines
-			_vblankEnd = 239 + 50 + 20;	// picture height + (postrender blanking lines - 1) + vblank length
+			// (picture height + border line) + postrender blanking lines + 50
+			_nmiScanline = 240 + 1 + 50;
+			// (picture height + border line) + (postrender blanking lines - 1) + 50 + vblank length
+			_vblankEnd = 240 + 50 + 20;
 			_standardNmiScanline = _nmiScanline;
 			_standardVblankEnd = _vblankEnd;
 			_masterClockDivider = 5;
@@ -1344,11 +1350,11 @@ void PPU::Exec()
 		}
 	}
 
-	_startingPhase = _cycle % 3;
-
 	if(_needStateUpdate) {
 		UpdateState();
 	}
+
+	_startingPhase = _cycle % 3;
 }
 
 void PPU::UpdateState()

--- a/Core/PPU.cpp
+++ b/Core/PPU.cpp
@@ -114,30 +114,31 @@ void PPU::SetNesModel(NesModel model)
 {
 	_nesModel = model;
 
+	// https://www.nesdev.org/wiki/Cycle_reference_chart
 	switch(_nesModel) {
 		case NesModel::Auto:
 			//Should never be Auto
 			break;
 
 		case NesModel::NTSC:
-			_nmiScanline = 241;
-			_vblankEnd = 260;
-			_standardNmiScanline = 241;
-			_standardVblankEnd = 260;
+			_nmiScanline = 240 + 1;		// picture height + postrender blanking lines
+			_vblankEnd = 240 + 20;		// picture height + (postrender blanking lines - 1) + vblank length
+			_standardNmiScanline = _nmiScanline;
+			_standardVblankEnd = _vblankEnd;
 			_masterClockDivider = 4;
 			break;
 		case NesModel::PAL:
-			_nmiScanline = 241;
-			_vblankEnd = 310;
-			_standardNmiScanline = 241;
-			_standardVblankEnd = 310;
+			_nmiScanline = 239 + 1;		// picture height + postrender blanking lines
+			_vblankEnd = 239 + 70;		// picture height + (postrender blanking lines - 1) + vblank length
+			_standardNmiScanline = _nmiScanline;
+			_standardVblankEnd = _vblankEnd;
 			_masterClockDivider = 5;
 			break;
 		case NesModel::Dendy:
-			_nmiScanline = 291;
-			_vblankEnd = 310;
-			_standardNmiScanline = 291;
-			_standardVblankEnd = 310;
+			_nmiScanline = 239 + 51;		// picture height + postrender blanking lines
+			_vblankEnd = 239 + 50 + 20;	// picture height + (postrender blanking lines - 1) + vblank length
+			_standardNmiScanline = _nmiScanline;
+			_standardVblankEnd = _vblankEnd;
 			_masterClockDivider = 5;
 			break;
 	}

--- a/Core/PPU.cpp
+++ b/Core/PPU.cpp
@@ -105,7 +105,7 @@ void PPU::Reset()
 	memset(_oamDecayCycles, 0, sizeof(_oamDecayCycles));
 	_enableOamDecay = _settings->CheckFlag(EmulationFlags::EnableOamDecay);
 
-	_isDotBypassed = false;
+	_startingPhase = 0;
 
 	UpdateMinimumDrawCycles();
 }
@@ -999,21 +999,13 @@ void PPU::ProcessScanline()
 			LoadTileInfo();
 		}
 	} else if(_cycle == 337 || _cycle == 339) {
-		if(_scanline == -1 && _cycle == 339 && (_frameCount & 0x01) && _nesModel == NesModel::NTSC && _settings->GetPpuModel() == PpuModel::Ppu2C02) {
-			if (IsRenderingEnabled()) {
-			//This behavior is NTSC-specific - PAL frames are always the same number of cycles
-			//"With rendering enabled, each odd PPU frame is one PPU clock shorter than normal" (skip from 339 to 0, going over 340)
-				_cycle = 340;
-				_isDotBypassed = false;
-			}
-			else {
-				// "By keeping rendering disabled until after the time when the clock is skipped on odd frames,
-				// you can get a different color dot crawl pattern than normal."
-				_isDotBypassed = true;
-			}
-		}
 		if (IsRenderingEnabled()) {
 			ReadVram(GetNameTableAddr());
+			if (_scanline == -1 && _cycle == 339 && (_frameCount & 0x01) && _nesModel == NesModel::NTSC && _settings->GetPpuModel() == PpuModel::Ppu2C02) {
+				//This behavior is NTSC-specific - PAL frames are always the same number of cycles
+				//"With rendering enabled, each odd PPU frame is one PPU clock shorter than normal" (skip from 339 to 0, going over 340)
+				_cycle = 340;
+			}
 		}
 	}
 }
@@ -1350,6 +1342,8 @@ void PPU::Exec()
 			}
 		}
 	}
+
+	_startingPhase = _cycle % 3;
 
 	if(_needStateUpdate) {
 		UpdateState();

--- a/Core/PPU.h
+++ b/Core/PPU.h
@@ -109,6 +109,9 @@ class PPU : public IMemoryHandler, public Snapshotable
 		bool _enableOamDecay;
 		bool _corruptOamRow[32];
 
+		// https://forums.nesdev.org/viewtopic.php?p=30625#p30625
+		bool _isDotBypassed;
+
 		void UpdateStatusFlag();
 
 		void SetControlRegister(uint8_t value);
@@ -215,6 +218,11 @@ class PPU : public IMemoryHandler, public Snapshotable
 		uint32_t GetFrameCount()
 		{
 			return _frameCount;
+		}
+
+		bool IsDotBypassed()
+		{
+			return _isDotBypassed;
 		}
 
 		uint32_t GetFrameCycle()

--- a/Core/PPU.h
+++ b/Core/PPU.h
@@ -110,7 +110,7 @@ class PPU : public IMemoryHandler, public Snapshotable
 		bool _corruptOamRow[32];
 
 		// https://forums.nesdev.org/viewtopic.php?p=30625#p30625
-		bool _isDotBypassed;
+		uint8_t _startingPhase;
 
 		void UpdateStatusFlag();
 
@@ -220,9 +220,9 @@ class PPU : public IMemoryHandler, public Snapshotable
 			return _frameCount;
 		}
 
-		bool IsDotBypassed()
+		uint8_t GetStartingPhase()
 		{
-			return _isDotBypassed;
+			return _startingPhase;
 		}
 
 		uint32_t GetFrameCycle()


### PR DESCRIPTION
When rendering is disabled while an odd frame skips the first dot, the color subcarrier pattern exhibits three different field phases instead of the usual two.
https://forums.nesdev.org/viewtopic.php?p=30625#p30625