### PR TITLE
n163: Account for battery flag when initializing internal ram

### DIFF
--- a/Core/Namco163.h
+++ b/Core/Namco163.h
@@ -60,6 +60,7 @@ protected:
 	void InitMapper() override
 	{
 		_audio.reset(new Namco163Audio(_console));
+		_audio->InitializeInternalRam(HasBattery());
 
 		switch(_romInfo.MapperID) {
 			case 19:

--- a/Core/Namco163Audio.h
+++ b/Core/Namco163Audio.h
@@ -144,7 +144,7 @@ protected:
 public:
 	Namco163Audio(shared_ptr<Console> console) : BaseExpansionAudio(console)
 	{
-		_console->InitializeRam(_internalRam, sizeof(_internalRam));
+		memset(_internalRam, 0, sizeof(_internalRam));
 		memset(_channelOutput, 0, sizeof(_channelOutput));
 		_ramPosition = 0;
 		_autoIncrement = false;
@@ -152,6 +152,14 @@ public:
 		_currentChannel = 7;
 		_lastOutput = 0;
 		_disableSound = false;
+	}
+
+	void InitializeInternalRam(bool hasBattery)
+	{
+		if (!hasBattery)
+		{
+			_console->InitializeRam(_internalRam, sizeof(_internalRam));
+		}
 	}
 
 	uint8_t* GetInternalRam()


### PR DESCRIPTION
Basically, if loaded rom has battery enabled, then leave internal ram initialized with all 00, else follow ram initialization 
 settings (random, all FF, all 00)


followup for https://github.com/NovaSquirrel/Mesen-X/issues/145#issuecomment-1378147411